### PR TITLE
compile on centos 7

### DIFF
--- a/src/openssladapter.cc
+++ b/src/openssladapter.cc
@@ -9,6 +9,7 @@
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "logging.h"


### PR DESCRIPTION
Unistd not luckily included on centos 7.
Now builds just fine.
